### PR TITLE
Fix container usage conflicts across exercises

### DIFF
--- a/ex01/RPN.hpp
+++ b/ex01/RPN.hpp
@@ -2,12 +2,11 @@
 #define RPN_HPP
 
 #include <string>
-#include <vector>
 #include <stack>
 
 class RPN {
 private:
-    bool tokenizeAndValidate(const std::string& expr, std::vector<std::string>& tokens);
+    bool tokenizeAndValidate(const std::string& expr);
     bool applyOp(std::stack<long>& st, char op);
     bool safeAdd(long a, long b, long& result);
     bool safeSub(long a, long b, long& result);


### PR DESCRIPTION
## Problem

The original implementation had a container usage conflict:
- ex00 (BitcoinExchange): uses \`std::map\`
- ex01 (RPN): uses \`std::vector\` + \`std::stack\`  
- ex02 (PmergeMe): uses \`std::vector\` + \`std::deque\`

Both ex01 and ex02 were using \`std::vector\`, violating the constraint that each container can only be used once across all exercises.

## Solution

Refactored ex01 (RPN) to eliminate \`std::vector\` dependency:

### Changes Made
1. **Header refactoring**: Removed \`std::vector\` include and updated \`tokenizeAndValidate\` signature
2. **Implementation optimization**: Replaced vector-based tokenization with direct parsing approach that processes tokens on-the-fly

### Final Container Usage
- **ex00**: \`std::map\` only
- **ex01**: \`std::stack\` only  
- **ex02**: \`std::vector\` + \`std::deque\`

## Benefits
- ✅ Resolves container usage conflicts
- ✅ Maintains full functionality of RPN calculator
- ✅ Improves memory efficiency (no intermediate token storage)
- ✅ Preserves all validation logic and error handling

## Testing
The refactored RPN implementation maintains the same interface and behavior as before, ensuring compatibility with existing tests.